### PR TITLE
feat: add support for PS4 controller 054c:05c4

### DIFF
--- a/dsdrv/controllers.py
+++ b/dsdrv/controllers.py
@@ -45,6 +45,7 @@ class controllers(Enum):
 products = {
     "09cc": controllers.DualShock4,
     "054c": controllers.DualShock4,
+    "05c4": controllers.DualShock4,
     "0ce6": controllers.DualSense
 }
 


### PR DESCRIPTION
I have a genuine PS4 controller here with PID/VID `054c:05c4`. Output of dmesg:

```
[  120.876301] usb 1-2: New USB device found, idVendor=054c, idProduct="05c4", bcdDevice= 1.00
[  120.876305] usb 1-2: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[  120.876307] usb 1-2: Product: Wireless Controller
[  120.876308] usb 1-2: Manufacturer: Sony Computer Entertainment
[  120.879190] playstation 0003:054C:05C4.0006: hidraw4: USB HID v1.11 Gamepad [Sony Computer Entertainment Wireless Controller] on usb-0000:00:14.0-2/input0
[  120.936040] input: Sony Computer Entertainment Wireless Controller as /devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.0/0003:054C:05C4.0006/input/input30
[  120.936277] input: Sony Computer Entertainment Wireless Controller Motion Sensors as /devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.0/0003:054C:05C4.0006/input/input31
[  120.936431] input: Sony Computer Entertainment Wireless Controller Touchpad as /devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.0/0003:054C:05C4.0006/input/input32
[  120.936674] playstation 0003:054C:05C4.0006: Registered DualShock4 controller hw_version=0x00003100 fw_version=0x0000004d
[  676.945125] usb 1-2: USB disconnect, device number 6
[  677.322214] usb 1-2: new full-speed USB device number 7 using xhci_hcd
[  677.445650] usb 1-2: Device not responding to setup address.
[  677.652213] usb 1-2: Device not responding to setup address.
[  677.858726] usb 1-2: device not accepting address 7, error -71
[  686.073029] Bluetooth: HIDP (Human Interface Emulation) ver 1.2
[  686.073034] Bluetooth: HIDP socket layer initialized
[  686.073516] playstation 0005:054C:05C4.0007: unknown main item tag 0x0
[  686.074317] playstation 0005:054C:05C4.0007: hidraw4: BLUETOOTH HID v1.00 Gamepad [Wireless Controller] on 00:09:dd:10:3a:80
[  686.117796] input: Wireless Controller as /devices/pci0000:00/0000:00:14.0/usb1/1-9/1-9:1.0/bluetooth/hci0/hci0:41/0005:054C:05C4.0007/input/input33
[  686.118098] input: Wireless Controller Motion Sensors as /devices/pci0000:00/0000:00:14.0/usb1/1-9/1-9:1.0/bluetooth/hci0/hci0:41/0005:054C:05C4.0007/input/input34
[  686.118297] input: Wireless Controller Touchpad as /devices/pci0000:00/0000:00:14.0/usb1/1-9/1-9:1.0/bluetooth/hci0/hci0:41/0005:054C:05C4.0007/input/input35
[  686.118562] playstation 0005:054C:05C4.0007: Registered DualShock4 controller hw_version=0x00003100 fw_version=0x0000004d
[  771.901226] input: Sony Computer Entertainment Wireless Controller as /devices/virtual/input/input36
```

Without this change, an [error occurs](https://github.com/git-developer/batocera-extra/issues/3#issuecomment-1606576020).