### PR TITLE
feat: add support for PS5 controller with different name

### DIFF
--- a/dsdrv/backends/hidraw.py
+++ b/dsdrv/backends/hidraw.py
@@ -123,8 +123,10 @@ class HidrawUSBDSDevice(HidrawDSDevice):
 
 HID_DEVICES = {
     "Sony Interactive Entertainment Wireless Controller": HidrawUSBDSDevice,
+    "Sony Interactive Entertainment DualSense Wireless Controller": HidrawUSBDSDevice,
     "Sony Computer Entertainment Wireless Controller": HidrawUSBDSDevice,
     "Wireless Controller": HidrawBluetoothDSDevice,
+    "DualSense Wireless Controller": HidrawBluetoothDSDevice,
 }
 
 


### PR DESCRIPTION
I have a genuine PS5 controller here whose name differs from the names currently supported by dsdrv:
* `Sony Interactive Entertainment DualSense Wireless Controller` (USB)
* `DualSense Wireless Controller` (Bluetooth)

I used the following command to find out the name:
```evtest </dev/null 2>&1 | grep -ioP '/dev/input/event.*:\s*\K.*controller.*$'```

I successfully tested that dsdrv provides motion and touch for the controller using this patch.